### PR TITLE
Replace color identifier in 'accent_alternate'

### DIFF
--- a/main.valette/scheme.json
+++ b/main.valette/scheme.json
@@ -726,7 +726,7 @@
                 "color_identifier": "azure_300"
             },
              "accent_alternate": {
-                "color_identifier": "azure_a100"
+                "color_identifier": "azure_A100"
             },
             "action_sheet_action_foreground": {
                 "color_identifier": "azure_300"


### PR DESCRIPTION
Replace color identifier 'azure_a100' in 'accent_alternate' with 'azure_A100' in bright_light theme