### PR TITLE
fix: missing color `azure_A400` for web

### DIFF
--- a/main.valette/palette_web.json
+++ b/main.valette/palette_web.json
@@ -1,7 +1,7 @@
 {
-    "azure_a100": "#0077FF",
+    "azure_A100": "#0077FF",
     "azure_300": "#2B81D6",
-    "azure_a400": "#2873C7",
+    "azure_A400": "#2873C7",
     "black": "#000000",
     "black_alpha4": "#0A000000",
     "black_alpha8": "#14000000",

--- a/main.valette/scheme_web.json
+++ b/main.valette/scheme_web.json
@@ -5,7 +5,7 @@
             "accent": {
                 "color_identifier": "sky_300"
             },
-             "accent_alternate": {
+            "accent_alternate": {
                 "color_identifier": "white"
             },
             "action_sheet_action_foreground": {
@@ -813,8 +813,8 @@
             "accent": {
                 "color_identifier": "azure_300"
             },
-             "accent_alternate": {
-                "color_identifier": "azure_a100"
+            "accent_alternate": {
+                "color_identifier": "azure_A100"
             },
             "action_sheet_action_foreground": {
                 "color_identifier": "azure_300",
@@ -1090,7 +1090,7 @@
                 "color_identifier": "steel_gray_200"
             },
             "header_tint_alternate": {
-                "color_identifier": "azure_a100"
+                "color_identifier": "azure_A100"
             },
             "icon_alpha_placeholder": {
                 "color_identifier": "white",
@@ -1340,7 +1340,7 @@
                 "deprecated_for_web": true
             },
             "feed_recommended_friend_promo_background": {
-                "color_identifier": "azure_a400",
+                "color_identifier": "azure_A400",
                 "deprecated_for_web": true
             },
             "overlay_status_background": {


### PR DESCRIPTION
**Проблема**

В [palette_web.json](https://github.com/VKCOM/Appearance/blob/6f539e4bfd88fc3dff50027fb615a9424db4e54c/main.valette/palette_web.json#L4) задан цвет `azure_a400`

https://github.com/VKCOM/Appearance/blob/6f539e4bfd88fc3dff50027fb615a9424db4e54c/main.valette/palette_web.json#L4


Но в [scheme_web.json](https://github.com/VKCOM/Appearance/blob/6f539e4bfd88fc3dff50027fb615a9424db4e54c/main.valette/scheme_web.json) используется `azure_A400` вместо `azure_a400`. Из-за этого фейлится сборка

https://github.com/VKCOM/Appearance/blob/6f539e4bfd88fc3dff50027fb615a9424db4e54c/main.valette/scheme_web.json#L896-L904

**Решение**
Переименовать `azure_a400` в `azure_A400`