### PR TITLE
fix content_tint_background для web

### DIFF
--- a/main.valette/scheme_web.json
+++ b/main.valette/scheme_web.json
@@ -139,7 +139,7 @@
                 "deprecated_for_web": true
             },
             "content_tint_background": {
-                "color_identifier": "gray_850",
+                "color_identifier": "gray_800",
                 "transparent_version": true
             },
             "content_tint_foreground": {


### PR DESCRIPTION
исправлен цвет, был gray_850, это не верный, исправлено на gray_800 для Dark темы web